### PR TITLE
Bugfix for slide edit / show

### DIFF
--- a/app/controllers/slides_controller.rb
+++ b/app/controllers/slides_controller.rb
@@ -52,7 +52,7 @@ class SlidesController < ApplicationController
   end
 
   def slides_params
-    params.require(:slide).permit(:narration, :photo)
+    params.require(:slide).permit(:narration, :photo, :json)
   end
 
   def slides_coords

--- a/app/views/slides/_edit_form.html.erb
+++ b/app/views/slides/_edit_form.html.erb
@@ -10,7 +10,8 @@
       <!-- editor container -->
       <div id="editor-container">
       </div>
-      <%= f.input :narration, as: :hidden, input_html: {class: "slide_narration", id: "narration"} %>
+      <%= f.input :json, as: :hidden, input_html: { id: "json"} %>
+      <%= f.input :narration, as: :hidden, input_html: { id: "narration"} %>
 
     </div>
   </div>

--- a/app/views/slides/edit.html.erb
+++ b/app/views/slides/edit.html.erb
@@ -71,7 +71,12 @@
     let slideID = "#edit_slide_" + "<%= j @slide.id.to_s %>";
 
     $(slideID).submit(function() {
+      // this one works for quill rendering
       $('#narration').val(JSON.stringify(editor.getContents()));
+      let container = $('.ql-editor');
+      // this one works for html
+      // $('#narration').val(JSON.stringify(container.html()));
+      // container.firstChild.innerHTML
       return true; // return false to cancel form action
     });
 

--- a/app/views/slides/edit.html.erb
+++ b/app/views/slides/edit.html.erb
@@ -66,17 +66,18 @@
       theme: 'snow'
     });
 
-    editor.setContents(<%= @slide.narration.html_safe unless @slide.narration.nil? %>);
+    editor.setContents(<%= @slide.json.html_safe unless @slide.json.nil? %>);
 
-    let slideID = "#edit_slide_" + "<%= j @slide.id.to_s %>";
+    const slideID = "#edit_slide_" + "<%= j @slide.id.to_s %>";
 
     $(slideID).submit(function() {
       // this one works for quill rendering
-      $('#narration').val(JSON.stringify(editor.getContents()));
-      let container = $('.ql-editor');
+      $('#json').val(JSON.stringify(editor.getContents()));
+
       // this one works for html
-      // $('#narration').val(JSON.stringify(container.html()));
-      // container.firstChild.innerHTML
+      let container = $('.ql-editor');
+      $('#narration').val(JSON.stringify(container.html()));
+
       return true; // return false to cancel form action
     });
 

--- a/app/views/slides/show.html.erb
+++ b/app/views/slides/show.html.erb
@@ -4,7 +4,7 @@
   <% end %>
   <div class="container">
     <p>
-      <%= @slide.narration %>
+      <%= @slide.narration.html_safe %>
     </p>
     <% unless @up_slide.nil? %>
       <%= link_to "Up",   story_slide_path(@story, @up_slide), id: "up"%>

--- a/db/migrate/20171117145929_add_json_to_slides.rb
+++ b/db/migrate/20171117145929_add_json_to_slides.rb
@@ -1,0 +1,5 @@
+class AddJsonToSlides < ActiveRecord::Migration[5.0]
+  def change
+    add_column :slides, :json, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171116154326) do
+ActiveRecord::Schema.define(version: 20171117145929) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,12 +37,13 @@ ActiveRecord::Schema.define(version: 20171116154326) do
   end
 
   create_table "slides", force: :cascade do |t|
-    t.text     "narration"
+    t.jsonb    "narration"
     t.integer  "x_axis"
     t.integer  "y_axis"
     t.integer  "story_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text     "json"
     t.index ["story_id"], name: "index_slides_on_story_id", using: :btree
   end
 


### PR DESCRIPTION
Because of the implementation of Quill, the show wasn't working properly, showing the literal JSON instead of the rich text. Fixed that by creating a new column in the Slides table. Now, json stores the json to render it properly in the text editor and narration stores the proper html to render it in the show page

**db:migrate**