### PR TITLE
Fixed bug that crashed story map for new slides

### DIFF
--- a/app/controllers/slides_controller.rb
+++ b/app/controllers/slides_controller.rb
@@ -96,6 +96,6 @@ class SlidesController < ApplicationController
   end
 
   def slides_coords
-    params.require(:slide).permit(:x_axis, :y_axis)
+    params.require(:slide).permit(:x_axis, :y_axis, :name)
   end
 end

--- a/app/views/slides/_new_form.html.erb
+++ b/app/views/slides/_new_form.html.erb
@@ -1,4 +1,5 @@
 <%= simple_form_for([@story, Slide.new]) do |f| %>
+  <%= f.input :name  , as: :hidden, input_html: {value: ""}  %>
   <%= f.input :x_axis, as: :hidden, input_html: {value: local_assigns[:x]} %>
   <%= f.input :y_axis, as: :hidden, input_html: {value: local_assigns[:y]} %>
   <%= f.button :submit, class: "btn btn-create ", value: "+", data: { 'disable-with': '+'} %>


### PR DESCRIPTION
New slides were being created with name = nil, which would cause the map to break if you created and instantly tried to check the map. Changed that by setting the name = "" (empty string), which the map can handle